### PR TITLE
hotfix: correct payload for upload avatar

### DIFF
--- a/apps/web/src/components/avatars/create-avatar-dialog.tsx
+++ b/apps/web/src/components/avatars/create-avatar-dialog.tsx
@@ -116,7 +116,7 @@ export function CreateAvatarDialog({
     }) => {
       if (data.file) {
         const formData = new FormData();
-        formData.append('name', data.username);
+        formData.append('username', data.username);
         formData.append('image', data.file);
         return await uploadAvatar(formData);
       } else {


### PR DESCRIPTION
Hotfix: upload avatar payload wrong in web

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the form field used when uploading an avatar in the Create Avatar dialog, ensuring the username is sent correctly.
  * Resolves issues where avatar uploads could fail or not associate with the correct user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->