### PR TITLE
hotfix: prod build fail vercel

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,3 @@
 # 2. SPECIFIC OWNERS (Tagged for specific code paths)
 
 # Web (Frontend) application
-/apps/web/ @Anmol-TheDev
-
-# UI components package
-/packages/ui/ @Anmol-TheDev

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -44,7 +44,9 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.17.1",
     "uuid": "^11.1.0",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "@fastify/swagger": "^9.5.2",
+    "@fastify/swagger-ui": "^5.2.3"
   },
   "devDependencies": {
     "@types/supertest": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -29,9 +29,5 @@
   },
   "resolutions": {
     "@types/react": "19.2.0"
-  },
-  "dependencies": {
-    "@fastify/swagger": "^9.5.2",
-    "@fastify/swagger-ui": "^5.2.3"
-   }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,19 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      '@fastify/swagger':
-        specifier: ^9.5.2
-        version: 9.5.2
-      '@fastify/swagger-ui':
-        specifier: ^5.2.3
-        version: 5.2.3
-      g:
-        specifier: ^2.0.1
-        version: 2.0.1
-      pnpm:
-        specifier: ^10.18.1
-        version: 10.18.1
     devDependencies:
       eslint:
         specifier: ^9.34.0
@@ -60,6 +47,12 @@ importers:
       '@fastify/rate-limit':
         specifier: ^10.3.0
         version: 10.3.0
+      '@fastify/swagger':
+        specifier: ^9.5.2
+        version: 9.5.2
+      '@fastify/swagger-ui':
+        specifier: ^5.2.3
+        version: 5.2.3
       '@repo/shared-types':
         specifier: workspace:^
         version: link:../../packages/shared-types
@@ -3184,9 +3177,6 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
-  g@2.0.1:
-    resolution: {integrity: sha512-Fi6Ng5fZ/ANLQ15H11hCe+09sgUoNvDEBevVgx3KoYOhsH5iLNPn54hx0jPZ+3oSWr+xajnp2Qau9VmPsc7hTA==}
-
   geist@1.5.1:
     resolution: {integrity: sha512-mAHZxIsL2o3ZITFaBVFBnwyDOw+zNLYum6A6nIjpzCGIO8QtC3V76XF2RnZTyLx1wlDTmMDy8jg3Ib52MIjGvQ==}
     peerDependencies:
@@ -4277,11 +4267,6 @@ packages:
   pkg-dir@4.2.0:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
-
-  pnpm@10.18.1:
-    resolution: {integrity: sha512-d6iEoWXLui2NHBnjtIgO7m0vyr0Nh5Eh4oIZa4AEI1HV6zygk1+lmdodxRJlzGiBatK93Sot5eqf35KtvsfNNA==}
-    engines: {node: '>=18.12'}
-    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -8255,8 +8240,6 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
-  g@2.0.1: {}
-
   geist@1.5.1(next@15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
       next: 15.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -9511,8 +9494,6 @@ snapshots:
   pkg-dir@4.2.0:
     dependencies:
       find-up: 4.1.0
-
-  pnpm@10.18.1: {}
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
- vercel build failed fix
- fastify swagger deps sent to backend from root
- removed aj from tagging for review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated backend dependencies to enable interactive API documentation tooling.
  - Simplified the root package manifest by removing unused dependencies while retaining necessary resolutions.
  - Adjusted repository ownership rules to remove explicit owners for certain paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->