### PR TITLE
feat: added avatar in templates showing

### DIFF
--- a/apps/web/src/app/dashboard/send/page.tsx
+++ b/apps/web/src/app/dashboard/send/page.tsx
@@ -71,6 +71,7 @@ export default function SendMessagePage() {
 
   const handleClearMessage = () => {
     // Hard refresh to clear everything
+    // TODO: improve thiss function
     window.location.href = pathname;
   };
 

--- a/apps/web/src/app/dashboard/send/page.tsx
+++ b/apps/web/src/app/dashboard/send/page.tsx
@@ -83,8 +83,8 @@ export default function SendMessagePage() {
     setSelectedTemplateId(undefined);
     setHideSelectTemplate(false);
 
-    // Clear all query params
-    router.push(pathname);
+    // Clear all query params - use replace to avoid adding to history
+    router.replace('/dashboard/send');
   };
 
   const { data: webhooks = [], isLoading: isLoadingWebhooks } = useQuery({

--- a/apps/web/src/app/dashboard/send/page.tsx
+++ b/apps/web/src/app/dashboard/send/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState, useEffect, useCallback, useRef } from 'react';
 import { useSearchParams, useRouter, usePathname } from 'next/navigation';
 import {
   Select,
@@ -62,6 +62,7 @@ export default function SendMessagePage() {
   const [selectedAvatar, setSelectedAvatar] = useState<Avatar | undefined>();
   const [hideSelectTemplate, setHideSelectTemplate] = useState(false);
   const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+  const isClearingRef = useRef(false);
 
   // Mention autocomplete state
   const [showMentionDropdown, setShowMentionDropdown] = useState(false);
@@ -70,6 +71,7 @@ export default function SendMessagePage() {
   const [mentionSearchQuery, setMentionSearchQuery] = useState('');
 
   const handleClearMessage = () => {
+    isClearingRef.current = true;
     // Clear all message state
     setMessage({
       content: '',
@@ -166,6 +168,12 @@ export default function SendMessagePage() {
   }, [initialWebhookId]);
 
   useEffect(() => {
+    // Don't load template if we're in the process of clearing
+    if (isClearingRef.current) {
+      isClearingRef.current = false;
+      return;
+    }
+
     if (
       initialTemplateId &&
       templates.length > 0 &&

--- a/apps/web/src/app/dashboard/templates/page.tsx
+++ b/apps/web/src/app/dashboard/templates/page.tsx
@@ -8,6 +8,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import {
+  Avatar as AvatarComponent,
+  AvatarImage,
+  AvatarFallback,
+} from '@/components/ui/avatar';
+import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -25,7 +30,8 @@ import {
 } from '@/components/ui/alert-dialog';
 import { useAuth } from '@/contexts/auth-context';
 import { templateQueries } from '@/lib/api/queries/message-template';
-import type { MessageTemplate } from '@repo/shared-types';
+import { getAllAvatars } from '@/lib/api/queries/avatar';
+import type { MessageTemplate, Avatar } from '@repo/shared-types';
 import {
   Search,
   FileText,
@@ -51,6 +57,17 @@ export default function TemplatesPage() {
     queryFn: templateQueries.getAllTemplates,
     enabled: !!user,
   });
+
+  const { data: avatars = [] } = useQuery<Avatar[]>({
+    queryKey: ['avatars'],
+    queryFn: getAllAvatars,
+    enabled: !!user,
+  });
+
+  const getAvatarById = (avatarId?: string) => {
+    if (!avatarId) return null;
+    return avatars.find(avatar => avatar.id === avatarId);
+  };
 
   const deleteMutation = useMutation({
     mutationFn: templateQueries.deleteTemplate,
@@ -189,6 +206,27 @@ export default function TemplatesPage() {
                         : template.content || 'No content'}
                     </div>
                   </div>
+
+                  {template.avatar_ref &&
+                    (() => {
+                      const avatar = getAvatarById(template.avatar_ref);
+                      return avatar ? (
+                        <div className="flex items-center gap-2">
+                          <AvatarComponent className="size-8">
+                            <AvatarImage
+                              src={avatar.avatar_url || ''}
+                              alt={avatar.username}
+                            />
+                            <AvatarFallback className="bg-purple-500/20 text-purple-200 text-sm">
+                              {avatar.username.charAt(0).toUpperCase()}
+                            </AvatarFallback>
+                          </AvatarComponent>
+                          <span className="text-sm text-gray-300 font-medium">
+                            {avatar.username}
+                          </span>
+                        </div>
+                      ) : null;
+                    })()}
 
                   <div className="flex items-center justify-between">
                     {template.embeds && template.embeds.length > 0 && (

--- a/apps/web/src/app/dashboard/templates/page.tsx
+++ b/apps/web/src/app/dashboard/templates/page.tsx
@@ -144,7 +144,10 @@ export default function TemplatesPage() {
           {filteredTemplates.map(template => (
             <Card
               key={template._id}
-              className="bg-white/10 backdrop-blur-md border-white/20 hover:bg-white/15 transition-all duration-200 hover:shadow-lg hover:shadow-purple-500/10"
+              className="bg-white/10 backdrop-blur-md border-white/20 hover:bg-white/15 transition-all duration-200 hover:shadow-lg hover:shadow-purple-500/10 cursor-pointer"
+              onClick={() =>
+                router.push(`/dashboard/send?template=${template._id}`)
+              }
             >
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <CardTitle className="text-base font-medium text-white">
@@ -162,6 +165,7 @@ export default function TemplatesPage() {
                       <Button
                         variant="ghost"
                         className="h-8 w-8 p-0 text-gray-300 hover:text-white hover:bg-white/10"
+                        onClick={e => e.stopPropagation()}
                       >
                         <MoreHorizontal className="h-4 w-4" />
                       </Button>
@@ -171,14 +175,20 @@ export default function TemplatesPage() {
                       className="bg-slate-800/95 backdrop-blur-md border-white/20 text-white"
                     >
                       <DropdownMenuItem
-                        onClick={() => handleEditTemplate(template._id)}
+                        onClick={e => {
+                          e.stopPropagation();
+                          handleEditTemplate(template._id);
+                        }}
                         className="hover:bg-white/10 focus:bg-white/10"
                       >
                         <Edit className="mr-2 h-4 w-4" />
                         Edit
                       </DropdownMenuItem>
                       <DropdownMenuItem
-                        onClick={() => setDeleteDialogTemplate(template)}
+                        onClick={e => {
+                          e.stopPropagation();
+                          setDeleteDialogTemplate(template);
+                        }}
                         className="text-red-400 hover:bg-red-500/10 focus:bg-red-500/10"
                       >
                         <Trash2 className="mr-2 h-4 w-4" />

--- a/apps/web/src/app/dashboard/templates/page.tsx
+++ b/apps/web/src/app/dashboard/templates/page.tsx
@@ -154,12 +154,12 @@ export default function TemplatesPage() {
                   {template.name}
                 </CardTitle>
                 <div className="flex items-center gap-2">
-                  <Badge
+                  {/* <Badge
                     variant="secondary"
                     className="bg-purple-500/20 text-purple-200 border-purple-500/30"
                   >
                     TODO uses
-                  </Badge>
+                  </Badge> */}
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Templates can be pre-selected via URL query parameters and auto-load on page open.
  * Avatars are displayed with templates, can be synced from the URL, and template cards navigate directly to the send page.

* **Bug Fixes / Behavior**
  * Avatar sync and the Clear action now respect query-provided avatars, avoid unintended avatar overrides, and clear URL params consistently.
  * Clear button visibility updated to reflect selected avatar state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->